### PR TITLE
support recent versions of the Fantasy Land specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ The `LazyEither` type is used to represent a lazy `Either` value. It is similar 
 
 The implementation is more favorable than the `Future` type because it is very easy to compose elegant pipelines, and it handles errors nicely. If `fork`-like branching is desired, it can be done just by resolving the pipeline using `value` and checking whether the result `isLeft` or `isRight` (though branching is not usually needed). See the examples section for more details.
 
-The implementation follows the [Fantasy Land](https://github.com/fantasyland/fantasy-land) specifications. The `LazyEither` type is a `Functor`, `Applicative` and `Monad`. It is not (necessarily) a `Setoid` due to it's lazy/deferred nature. 
+The implementation follows the [Fantasy Land](https://github.com/fantasyland/fantasy-land) specifications. The `LazyEither` type is a `Functor`, `Applicative` and `Monad`. It is not (necessarily) a `Setoid` due to its lazy/deferred nature.
 
 
 ## Construction
 
-The `LazyEither` type consists of a single constructor that accepts a function which must accept a continuation function used to resolve the `LazyEither` instance into an `Either` type: 
+The `LazyEither` type consists of a single constructor that accepts a function which must accept a continuation function used to resolve the `LazyEither` instance into an `Either` type:
 
 ```hs
 LazyEither :: ((Either e a -> ()) -> ()) -> LazyEither e a
@@ -21,7 +21,7 @@ The resolved instance should be an [Either type](https://github.com/ramda/ramda-
 
 
 ```js
-//:: Number -> a -> LazyEither Error a
+//:: (Number, a) -> LazyEither (Either e a)
 let delayed = (ms, val) => LazyEither(resolve => {
   ms > 1000 ? resolve(S.Left(Error('Delay too long')))
             : setTimeout(() => resolve(S.Right(val)), ms)
@@ -29,34 +29,40 @@ let delayed = (ms, val) => LazyEither(resolve => {
 ```
 
 ```js
-delayed(500, 'Hello').value(result => console.log(result))  // returns Right('Hello')
-delayed(1001, 'Hey').value(result => console.log(result))  // returns Left(Error('Delay too long'))
+delayed(500, 'Hello').value(console.log)  // returns Right('Hello')
+delayed(1001, 'Hey').value(console.log)  // returns Left(Error('Delay too long'))
 ```
 
 
 ## Interaction
 
-Once a `LazyEither` instance has been created, the various methods attached to the instance can be used to instruct further transformations to take place. Nothing is actually executed until the `value` or `equals` method is called.
+Once a `LazyEither` instance has been created, the various methods attached to the instance can be used to instruct further transformations to take place. Nothing is actually executed until the `value` or `fantasy-land/equals` method is called.
 
-The `map`, `ap` and `chain` functions can be used to transform resolved values of a `LazyEither` instance.
+The `fantasy-land/map`, `fantasy-land/ap` and `fantasy-land/chain` functions can be used to transform resolved values of a `LazyEither` instance.
 
 ```js
-//:: String -> LazyEither Error [String]
-let ls = path => LazyEither(resolve =>
-  fs.readdir(path, (err, files) => resolve(err ? S.Left(err) : S.Right(files))))
+//:: String -> String -> String
+const join = S.curry2(path.join)
 
-//:: String -> LazyEither Error String
-let cat = file => LazyEither(resolve =>
-  fs.readFile(file, 'utf8', (err, data) => resolve(err ? S.Left(err) : S.Right(data))))
+//:: String -> LazyEither (Either e [String])
+const ls = path => LazyEither(resolve =>
+  fs.readdir(path, (err, files) => resolve(err ? S.Left(err) : S.Right(S.map(join(path), files)))))
 
-//:: String -> LazyEither Error String
-let catDir = dir => ls(dir.value).chain(R.traverse(LazyEither.of, cat)).map(R.join('\n'))
+//:: String -> LazyEither (Either e String)
+const cat = file => LazyEither(resolve =>
+  fs.readFile(file, {encoding: 'utf8'}, (err, data) => resolve(err ? S.Left(err) : S.Right(data))))
+
+//:: String -> LazyEither (Either e String)
+const catDir =
+S.pipe([ls,
+        S.chain(S.traverse(LazyEither, cat)),
+        S.map(S.unlines)])
 ```
 
-A `LazyEither` instance is executed when `value` or `equals` gets called:
+A `LazyEither` instance is executed when `value` or `fantasy-land/equals` gets called:
 
 ```js
-catDir(S.Right('.')).value(data => console.log(data.value))
+catDir(os.homedir()).value(S.either(console.error, console.log))
 ```
 
 
@@ -69,31 +75,38 @@ catDir(S.Right('.')).value(data => console.log(data.value))
 ```hs
 :: ((Either e a -> ()) -> ()) -> LazyEither e a
 ```
-Constructs a `LazyEither` instance that represents some action that may possibly fail. It takes a function which must accept a continuation function that takes an `Either` type used to represent success or failure. 
+
+Constructs a `LazyEither` instance that represents some action that may possibly fail. It takes a function which must accept a continuation function that takes an `Either` type used to represent success or failure.
 
 #### `LazyEither.Right`
+
 ```hs
 :: a -> LazyEither e a
 ```
+
 Creates a `LazyEither` instance that resolves to a `Right` with the given value.
 
 #### `LazyEither.Left`
+
 ```hs
 :: e -> LazyEither e a
 ```
+
 Creates a `LazyEither` instance that resolves to a `Left` with the given value.
 
 
 ### Static methods
 
-#### `LazyEither.of`
+#### `LazyEither['fantasy-land/of']`
+
 ```hs
 :: a -> LazyEither e a
 ```
 
-Creates a pure instance that resolves to a `Right` with the given value. This is also an instance method.
+Creates a pure instance that resolves to a `Right` with the given value.
 
 #### `LazyEither.lift`
+
 ```hs
 :: (a -> b) -> a -> LazyEither e b
 ```
@@ -101,6 +114,7 @@ Creates a pure instance that resolves to a `Right` with the given value. This is
 Lifts a function of arity `1` into one that returns a `LazyEither` instance.
 
 #### `LazyEither.liftN`
+
 ```hs
 :: n -> (a -> .. -> z) -> a -> .. -> z -> LazyEither e z
 ```
@@ -108,6 +122,7 @@ Lifts a function of arity `1` into one that returns a `LazyEither` instance.
 Lifts a function of arity `n` into one that returns a `LazyEither` instance.
 
 #### `LazyEither.promote`
+
 ```hs
 :: Either a b -> LazyEither a b
 ```
@@ -117,38 +132,50 @@ Promotes an `Either` type to a `LazyEither` type.
 
 ### Instance methods
 
-#### `lazyEither.map`
+#### `lazyEither['fantasy-land/map']`
+
 ```hs
 :: LazyEither e a ~> (a -> b) -> LazyEither e b
 ```
+
 Transforms the resolved `Either` value of this `LazyEither` instance with the given function. If the instance resolves as a `Left` value, the provided function is not called and the returned `LazyEither` instance will resolve with that `Left` value.
 
-#### `lazyEither.ap`
-```hs
-:: LazyEither e (a -> b) ~> LazyEither e a -> LazyEither e b
-```
-Applies the `Either` function of this `LazyEither` instance to the `Either` value of the provided `LazyEither` instance, producing a `LazyEither` instance of the result. If either `LazyEither` resolves as a `Left` value, then the returned `LazyEither` instance will resolve with that `Left` value.
+#### `lazyEither['fantasy-land/ap']`
 
-#### `lazyEither.chain`
+```hs
+:: LazyEither e a ~> LazyEither e (a -> b) -> LazyEither e b
+```
+
+Applies the `Either` function of the provided `LazyEither` instance to the `Either` value of this `LazyEither` instance, producing a `LazyEither` instance of the result. If either `LazyEither` resolves as a `Left` value, then the returned `LazyEither` instance will resolve with that `Left` value.
+
+#### `lazyEither['fantasy-land/chain']`
+
 ```hs
 :: LazyEither e a ~> (a -> LazyEither e b) -> LazyEither e b
 ```
+
 Calls the provided function with the value of this `LazyEither` instance, returning the new `LazyEither` instance. If either `LazyEither` instance resolves as a `Left` value, the returned `LazyEither` instance will resolve with that `Left` value. The provided function can be used to try to recover the error.
 
-#### `lazyEither.bimap`
+#### `lazyEither['fantasy-land/bimap']`
+
 ```hs
 :: LazyEither e a ~> (e -> f) -> (a -> b) -> LazyEither f b
 ```
+
 Uses the provided functions to transform this `LazyEither` instance when it resolves to a `Left` or a `Right` value, respectively.
 
 #### `lazyEither.value`
+
 ```hs
-:: LazyEither e a ~> ((Either e a) -> ()) -> ()
+:: LazyEither e a ~> (Either e a -> ()) -> ()
 ```
+
 Calls the provided function with the value of this `LazyEither` instance without returning a new `LazyEither` instance. It is similar to `Future.fork`. This function can be used as a final processing step for the returned `Either` value, or to create a branch of two seperate execution streams to handle the resolved `Left` or `Right` value.
 
-#### `lazyEither.equals`
+#### `lazyEither['fantasy-land/equals']`
+
 ```hs
-:: LazyEither a b ~> LazyEither c d -> ((Boolean) -> ()) -> ()
+:: LazyEither a b ~> LazyEither c d -> (Boolean -> ()) -> ()
 ```
-Compares the `Either` value of this `LazyEither` instance with the `Either` value of the provided `LazyEither` instance, and calls the provided function with the `Boolean` result of the comparison. Like `value`, this function will resolve the pipeline. The result will return `True` if both `Either` values match or `False` if they do not match.
+
+Compares the `Either` value of this `LazyEither` instance with the `Either` value of the provided `LazyEither` instance, and calls the provided function with the `Boolean` result of the comparison. Like `value`, this function will resolve the pipeline. The result will return `true` if both `Either` values match or `false` if they do not match.

--- a/examples/readme1.js
+++ b/examples/readme1.js
@@ -1,12 +1,12 @@
 'use strict'
-const LazyEither = require('lazy-either').LazyEither
+const LazyEither = require('..')
 const S = require('sanctuary')
 
-//:: (Num -> a) -> LazyEither (Either e a)
+//:: (Number, a) -> LazyEither (Either e a)
 let delayed = (ms, val) => LazyEither(resolve => {
   ms > 1000 ? resolve(S.Left(Error('Delay too long')))
             : setTimeout(() => resolve(S.Right(val)), ms)
 })
 
-delayed(500, 'Hello').value(result => console.log(result))  // returns Right('Hello')
-delayed(1001, 'Hey').value(result => console.log(result))  // returns Left(Error('Delay too long'))
+delayed(500, 'Hello').value(console.log)  // returns Right('Hello')
+delayed(1001, 'Hey').value(console.log)  // returns Left(Error('Delay too long'))

--- a/examples/vs-future1.js
+++ b/examples/vs-future1.js
@@ -1,35 +1,44 @@
 'use strict'
-/* The is the implementation using LazyEither. Notice that it's just one elegant pipeK with the safety of Either */
 const R  = require('ramda')
     , S  = require('sanctuary')
     , fs = require('fs')
-const LazyEither = require('lazy-either').LazyEither
- 
-let writeFile = R.curry((file, data) => {
-  return new LazyEither(resolve => {
-    fs.writeFile(file, data, err => resolve(err ? S.Left(err) : S.Right('Write successful')))
+    , os = require('os')
+    , path = require('path')
+const LazyEither = require('..')
+
+const join = S.curry2(path.join)
+
+const readDir = path =>
+  new LazyEither(resolve => {
+    fs.readdir(path,
+               (err, files) => resolve(err != null ? S.Left(err) : S.Right(S.map(join(path), files))))
   })
-})
 
-let readFile = path => {
-  return new LazyEither(resolve => {
-    fs.readFile(path, (err, data) => resolve(err ? S.Left(err) : S.Right(data.toString())))
+const readFile = path =>
+  new LazyEither(resolve => {
+    fs.readFile(path,
+                {encoding: 'utf8'},
+                (err, data) => resolve(err != null ? S.Left(err) : S.Right(data)))
   })
-}
 
-let readDir = path => { 
-  return new LazyEither(resolve => {
-    fs.readdir(path, (err, files) => resolve(err ? S.Left(err) : S.Right(files)))
+const writeFile = S.curry2((file, data) =>
+  new LazyEither(resolve => {
+    fs.writeFile(file,
+                 data,
+                 err => resolve(err != null ? S.Left(err) : S.Right('Write successful')))
   })
-}
+)
 
-let filterJs  = R.pipe(R.filter(file => /\.js$/.test(file)), LazyEither.of)
-  , readFiles = files => R.traverse(LazyEither.of, readFile, files)
+const getStats =
+S.pipe([readDir,
+        S.map(S.filter(S.test(/[.]js$/))),
+        S.chain(S.traverse(LazyEither, readFile)),
+        S.map(String),
+        S.map(S.matchAll(/require[(][^)]+[)]/g)),
+        S.map(S.prop('length')),
+        S.map(String),
+        S.map(S.concat('Total requires: ')),
+        S.chain(writeFile('stats.txt'))])
 
-let numRequires = file => LazyEither.Right(file.toString().split(/require\([^)]+\)/).length - 1)
-  , printTotal = total => LazyEither.Right(`Total requires: ${total}`)
-
-let getStats = R.pipeK(readDir, filterJs, readFiles, numRequires, printTotal, writeFile('stats.txt'))
-
-getStats(LazyEither.Right('.')).value(val => console.log(val))
-//getStats(LazyEither.Right('blablah')).value(val => console.log(val))
+getStats(__dirname).value(console.log)
+//getStats('blablah').value(console.log)

--- a/examples/vs-future2.js
+++ b/examples/vs-future2.js
@@ -1,5 +1,5 @@
 'use strict'
-/* This is the implementation using Futures. Notice how it doesn't have that extra type safety with Either, 
+/* This is the implementation using Futures. Notice how it doesn't have that extra type safety with Either,
  * the chain has a kink (chain1 and chain2), and worst of all, the pyramid of doom is back!
  */
 const futurizer = require('futurizer').futurizer

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.5.0",
+    "fantasy-land": "^3.2.0",
     "mocha": "^2.4.5"
   },
   "dependencies": {
     "ramda": "^0.19.1",
-    "sanctuary": "^0.9.0"
+    "sanctuary": "^0.12.2"
   }
 }

--- a/test/either.js
+++ b/test/either.js
@@ -1,7 +1,8 @@
 'use strict'
 const expect = require('chai').expect
 const LazyEither = require('../index')
-const R = require('ramda')
+const FL = require('fantasy-land')
+    , R = require('ramda')
     , S = require('sanctuary')
 
 describe('Constructors', function() {
@@ -19,15 +20,8 @@ describe('Constructors', function() {
     })
   })
 
-  it('should construct using LazyEither.of', function(done) {
-    LazyEither.of('good').value(res => {
-      expect(res).to.deep.equal(S.Right('good'))
-      done()
-    })
-  })
-
-  it('should update the instance using LazyEither.of', function(done) {
-    LazyEither.Left('bad').of('good').value(res => {
+  it('should construct using LazyEither["fantasy-land/of"]', function(done) {
+    S.of(LazyEither, 'good').value(res => {
       expect(res).to.deep.equal(S.Right('good'))
       done()
     })
@@ -64,7 +58,7 @@ describe('Chain', function() {
 
   it('should not execute the rest of the chain if it fails and should propagate the Left value', function(done) {
     let startTime = Date.now()
-    LazyEither.Left('bad').chain(this.delayed).value(res => {
+    LazyEither.Left('bad')[FL.chain](this.delayed).value(res => {
       let endTime = Date.now()
       expect(res).to.deep.equal(S.Left('bad'))
       expect(endTime - startTime).to.be.closeTo(0, 100)
@@ -74,7 +68,7 @@ describe('Chain', function() {
 
   it('should pass the result to the next item in the chain (1)', function(done) {
     let startTime = Date.now()
-    LazyEither.Right(1500).chain(this.delayed).value(res => {
+    LazyEither.Right(1500)[FL.chain](this.delayed).value(res => {
       let endTime = Date.now()
       expect(res).to.deep.equal(S.Left('Delay too long'))
       expect(endTime - startTime).to.be.closeTo(0, 100)
@@ -84,7 +78,7 @@ describe('Chain', function() {
 
   it('should pass the result to the next item in the chain (2)', function(done) {
     let startTime = Date.now()
-    LazyEither.Right(800).chain(this.delayed).value(res => {
+    LazyEither.Right(800)[FL.chain](this.delayed).value(res => {
       let endTime = Date.now()
       expect(res).to.deep.equal(S.Right('hello'))
       expect(endTime - startTime).to.be.closeTo(800, 100)
@@ -94,7 +88,7 @@ describe('Chain', function() {
 
   it('should pass the result to the next item in the chain (3)', function(done) {
     let startTime = Date.now()
-    LazyEither.Right(1001).chain(this.delayed).chain(LazyEither.lift(R.identity)).value(res => {
+    LazyEither.Right(1001)[FL.chain](this.delayed)[FL.chain](LazyEither.lift(R.identity)).value(res => {
       let endTime = Date.now()
       expect(res).to.deep.equal(S.Left('Delay too long'))
       expect(endTime - startTime).to.be.closeTo(0, 100)
@@ -104,7 +98,7 @@ describe('Chain', function() {
 
   it('should pass the result to the next item in the chain (4)', function(done) {
     let startTime = Date.now()
-    LazyEither.Right(1001).chain(LazyEither.lift(a => a - 1)).chain(this.delayed).value(res => {
+    LazyEither.Right(1001)[FL.chain](LazyEither.lift(a => a - 1))[FL.chain](this.delayed).value(res => {
       let endTime = Date.now()
       expect(res).to.deep.equal(S.Right('hello'))
       expect(endTime - startTime).to.be.closeTo(1000, 100)
@@ -114,7 +108,7 @@ describe('Chain', function() {
 
   it('should pass the result to the next item in the chain (5)', function(done) {
     let startTime = Date.now()
-    LazyEither.Left('bad').of(200).chain(this.delayed).chain(LazyEither.lift(hi => `${hi} world`)).value(res => {
+    LazyEither.Right(200)[FL.chain](this.delayed)[FL.chain](LazyEither.lift(hi => `${hi} world`)).value(res => {
       let endTime = Date.now()
       expect(res).to.deep.equal(S.Right('hello world'))
       expect(endTime - startTime).to.be.closeTo(200, 100)
@@ -125,20 +119,20 @@ describe('Chain', function() {
   it('should satisfy associativity', function(done) {
     let val1, val2
     let add3  = LazyEither.lift(R.add(3))
-      , mult2 = LazyEither.lift(R.multiply(2)) 
+      , mult2 = LazyEither.lift(R.multiply(2))
 
     let resolveIfDone = _ => { if (val1 && val2) done() }
 
-    LazyEither.Right(5).chain(add3).chain(mult2).value(res => {
+    LazyEither.Right(5)[FL.chain](add3)[FL.chain](mult2).value(res => {
       val1 = res
       expect(res).to.deep.equal(S.Right(16))
-      resolveIfDone() 
+      resolveIfDone()
     })
 
-    LazyEither.Right(5).chain(x => add3(x).chain(mult2)).value(res => {
+    LazyEither.Right(5)[FL.chain](x => add3(x)[FL.chain](mult2)).value(res => {
       val2 = res
       expect(res).to.deep.equal(S.Right(16))
-      resolveIfDone() 
+      resolveIfDone()
     })
   })
 })
@@ -147,35 +141,35 @@ describe('Chain', function() {
 
 describe('Functor', function() {
   it('should apply the map to a Right value (1)', function(done) {
-    LazyEither.Right(1).map(R.add(7)).value(res => {
+    LazyEither.Right(1)[FL.map](R.add(7)).value(res => {
       expect(res).to.deep.equal(S.Right(8))
       done()
     })
   })
 
   it('should apply the map to a Right value (2)', function(done) {
-    LazyEither.Right('foo').map(a => `${a} bar`).map(a => `${a} baz`).value(res => {
+    LazyEither.Right('foo')[FL.map](a => `${a} bar`)[FL.map](a => `${a} baz`).value(res => {
       expect(res).to.deep.equal(S.Right('foo bar baz'))
       done()
     })
   })
 
   it('should not apply the map function to a Left value (1)', function(done) {
-    LazyEither.Left('bad').map(a => `${a} bar`).map(a => `${a} baz`).value(res => {
+    LazyEither.Left('bad')[FL.map](a => `${a} bar`)[FL.map](a => `${a} baz`).value(res => {
       expect(res).to.deep.equal(S.Left('bad'))
       done()
     })
   })
 
   it('should satisfy identity (1)', function(done) {
-    LazyEither.Right('good').map(R.identity).value(res => {
+    LazyEither.Right('good')[FL.map](R.identity).value(res => {
       expect(res).to.deep.equal(S.Right('good'))
       done()
     })
   })
 
   it('should satisfy identity (2)', function(done) {
-    LazyEither.Left('bad').map(R.identity).value(res => {
+    LazyEither.Left('bad')[FL.map](R.identity).value(res => {
       expect(res).to.deep.equal(S.Left('bad'))
       done()
     })
@@ -185,16 +179,16 @@ describe('Functor', function() {
     let val1, val2
     let resolveIfDone = _ => { if (val1 && val2) done() }
 
-    LazyEither.Right(5).map(R.add(3)).map(R.multiply(2)).value(res => {
+    LazyEither.Right(5)[FL.map](R.add(3))[FL.map](R.multiply(2)).value(res => {
       val1 = res
       expect(res).to.deep.equal(S.Right(16))
-      resolveIfDone() 
+      resolveIfDone()
     })
 
-    LazyEither.Right(5).map(x => R.multiply(2)(R.add(3, x))).value(res => {
+    LazyEither.Right(5)[FL.map](x => R.multiply(2)(R.add(3, x))).value(res => {
       val2 = res
       expect(res).to.deep.equal(S.Right(16))
-      resolveIfDone() 
+      resolveIfDone()
     })
   })
 })
@@ -203,43 +197,43 @@ describe('Functor', function() {
 
 describe('Applicative', function() {
   it('should be apply the ap function', function(done) {
-    LazyEither.Right(R.multiply(3)).ap(LazyEither.Right(4)).value(res => {
+    LazyEither.Right(4)['fantasy-land/ap'](LazyEither.Right(R.multiply(3))).value(res => {
       expect(res).to.deep.equal(S.Right(12))
       done()
     })
   })
 
   it('should propagate a Left value (1)', function(done) {
-    LazyEither.Left('bad').ap(LazyEither.Right(2)).value(res => {
+    LazyEither.Right(2)[FL.ap](LazyEither.Left('bad')).value(res => {
       expect(res).to.deep.equal(S.Left('bad'))
       done()
     })
   })
 
   it('should propagate a Left value (2)', function(done) {
-    LazyEither.Right(R.add(5)).ap(LazyEither.Left('bad')).value(res => {
+    LazyEither.Left('bad')[FL.ap](LazyEither.Right(R.add(5))).value(res => {
       expect(res).to.deep.equal(S.Left('bad'))
       done()
     })
   })
 
   it('should be able to compose multiple ap functions', function(done) {
-    LazyEither.Right(R.multiply(2)).ap(LazyEither.Right(R.add(3)).ap(LazyEither.Right(5))).value(res => {
+    LazyEither.Right(5)[FL.ap](LazyEither.Right(R.add(3)))[FL.ap](LazyEither.Right(R.multiply(2))).value(res => {
       expect(res).to.deep.equal(S.Right(16))
       done()
     })
   })
 
   it('should satisfy identity', function(done) {
-    LazyEither.Right(R.identity).ap(LazyEither.Right('good')).value(res => {
+    LazyEither.Right('good')[FL.ap](LazyEither.Right(R.identity)).value(res => {
       expect(res).to.deep.equal(S.Right('good'))
       done()
     })
   })
 
   it('should satisfy homomorphism', function(done) {
-    LazyEither.of(R.add(3)).ap(LazyEither.of(5)).value(res => {
-      LazyEither.of(R.add(3, 5)).value(res2 => {
+    LazyEither.Right(5)[FL.ap](LazyEither.Right(R.add(3))).value(res => {
+      LazyEither.Right(R.add(3, 5)).value(res2 => {
         expect(res).to.deep.equal(res2)
         done()
       })
@@ -247,8 +241,8 @@ describe('Applicative', function() {
   })
 
   it('should satisfy interchange', function(done) {
-    LazyEither.of(R.add(3)).ap(LazyEither.of(5)).value(res => {
-      LazyEither.of(f => f(5)).ap(LazyEither.of(R.add(3))).value(res2 => {
+    LazyEither.Right(5)[FL.ap](LazyEither.Right(R.add(3))).value(res => {
+      LazyEither.Right(R.add(3))[FL.ap](LazyEither.Right(f => f(5))).value(res2 => {
         expect(res).to.deep.equal(S.Right(8))
         expect(res).to.deep.equal(res2)
         done()
@@ -261,43 +255,43 @@ describe('Applicative', function() {
 
 describe('Setoid (contitional)', function() {
   it('should return true if a and b are equal (reflexivity) (1)', function(done) {
-    LazyEither.Right('good').equals(LazyEither.Right('good'), res => {
+    LazyEither.Right('good')[FL.equals](LazyEither.Right('good'), res => {
       expect(res).to.be.true
       done()
     })
   })
 
   it('should return true if a and b are equal (reflexivity) (2)', function(done) {
-    LazyEither.Left('bad').equals(LazyEither.Left('bad'), res => {
+    LazyEither.Left('bad')[FL.equals](LazyEither.Left('bad'), res => {
       expect(res).to.be.true
       done()
     })
   })
 
   it('should return false if a and b are not equal (1)', function(done) {
-    LazyEither.Right(1).equals(LazyEither.Right(2), res => {
+    LazyEither.Right(1)[FL.equals](LazyEither.Right(2), res => {
       expect(res).to.be.false
       done()
     })
   })
 
   it('should return false if a and b are not equal (2)', function(done) {
-    LazyEither.Left(1).equals(LazyEither.Left(2), res => {
+    LazyEither.Left(1)[FL.equals](LazyEither.Left(2), res => {
       expect(res).to.be.false
       done()
     })
   })
 
   it('should return false if a and b are equal but Left and Right', function(done) {
-    LazyEither.Left(1).equals(LazyEither.Right(1), res => {
+    LazyEither.Left(1)[FL.equals](LazyEither.Right(1), res => {
       expect(res).to.be.false
       done()
     })
   })
 
   it('should satisfy symmetry', function(done) {
-    LazyEither.Right(7 + 5).equals(LazyEither.Right(3 * 4), res => {
-      LazyEither.Right(3 * 4).equals(LazyEither.Right(7 + 5), res2 => {
+    LazyEither.Right(7 + 5)[FL.equals](LazyEither.Right(3 * 4), res => {
+      LazyEither.Right(3 * 4)[FL.equals](LazyEither.Right(7 + 5), res2 => {
         expect(res).to.deep.equal(res2)
         done()
       })
@@ -305,9 +299,9 @@ describe('Setoid (contitional)', function() {
   })
 
   it('should satisfy transitivity', function(done) {
-    LazyEither.Right(7 + 5).equals(LazyEither.Right(3 * 4), res => {
-      LazyEither.Right(3 * 4).equals(LazyEither.Right(72 / 6), res2 => {
-        LazyEither.Right(7 + 5).equals(LazyEither.Right(72 / 6), res2 => {
+    LazyEither.Right(7 + 5)[FL.equals](LazyEither.Right(3 * 4), res => {
+      LazyEither.Right(3 * 4)[FL.equals](LazyEither.Right(72 / 6), res2 => {
+        LazyEither.Right(7 + 5)[FL.equals](LazyEither.Right(72 / 6), res2 => {
           expect(res).to.deep.equal(res2)
           done()
         })
@@ -322,7 +316,7 @@ describe('Lift', function() {
   it('should lift a function of arity 1', function(done) {
     let lifted = LazyEither.lift(R.multiply(3))
 
-    LazyEither.Right(3).chain(lifted).value(res => {
+    LazyEither.Right(3)[FL.chain](lifted).value(res => {
       expect(res).to.deep.equal(S.Right(9))
       done()
     })
@@ -332,7 +326,7 @@ describe('Lift', function() {
     let add  = R.curry((a, b, c, d, e) => a + b + c + d + e)
       , lifted = LazyEither.liftN(5, add)
 
-    LazyEither.Right(3).chain(lifted(4, 5, 6, 7)).value(res => {
+    LazyEither.Right(3)[FL.chain](lifted(4, 5, 6, 7)).value(res => {
       expect(res).to.deep.equal(S.Right(25))
       done()
     })


### PR DESCRIPTION
I actually think it would be a good idea to deprecate this project and update the readme to suggest that people use [Fluture][1] instead. If you'd like to keep this project around, though, you're welcome to merge this pull request.


[1]: https://github.com/fluture-js/Fluture
